### PR TITLE
fix-#172: Login of the user doesn't stay if I refresh the page ( Non - consistent ) solved.

### DIFF
--- a/frontend/src/layouts/header-layout.tsx
+++ b/frontend/src/layouts/header-layout.tsx
@@ -7,11 +7,12 @@ import Hero from '@/components/hero';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import { toast } from 'react-toastify';
-import userState from '@/utils/user-state';
 import { useCookies } from 'react-cookie'
+import userState from '@/utils/user-state';
 function header() {
   const navigate = useNavigate();
   const [allCookies, ,removeCookie] = useCookies(['accessToken']);
+
   const [accessToken, setAccessToken] = useState<string | null>(userState.getUser());
 
    useEffect(() => {

--- a/frontend/src/pages/signin-page.tsx
+++ b/frontend/src/pages/signin-page.tsx
@@ -31,9 +31,8 @@ function signin() {
           password,
         }
       );
-      userState.setUser(response?.data?.accessToken);
+      userState.setUser(response.data.accessToken);
       toast.success(response.data.message); 
-
       Cookies.set('accessToken',response?.data.accessToken, {
         expires: new Date(new Date().getTime() + 240 * 1000)
       });

--- a/frontend/src/pages/signup-page.tsx
+++ b/frontend/src/pages/signup-page.tsx
@@ -8,8 +8,8 @@ import 'react-toastify/dist/ReactToastify.css';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'react-toastify';
 import axios, { isAxiosError } from 'axios';
+import Cookies from 'js-cookie';
 import userState from '@/utils/user-state';
-
 function signin() {
   const navigate = useNavigate();
 
@@ -33,10 +33,14 @@ function signin() {
           password,
         }
       );
-
-      userState.setUser(response?.data?.accessToken);
+      userState.setUser(response.data.accessToken);
       toast.success(response.data.message);
-
+      Cookies.set('accessToken',response?.data.accessToken, {
+        expires: new Date(new Date().getTime() + 240 * 1000)
+      });
+      Cookies.set('refreshToken', response.data.refreshToken, {
+        expires: new Date(new Date().getTime() + 240 * 1000)
+      });
       reset();
       navigate('/');
     } catch (error) {


### PR DESCRIPTION
## Summary
solved the issue #172 
## Description
whenever we are refreshing the page the home page(header-layout) component will re-render if it is re-render the usestate is set to null because it is not persistent when the page is refresh even it is static

my approach-I got the access token and refresh token from the signin response and I set into the cookie section with expiry of 4 mins. Now the token won't lost it will store persistant in the cookie till the expiry 

## Images

_Include any relevant images or diagrams that can help reviewers visualize the changes, if applicable_

## Issue(s) Addressed

_Enter the issue number of the bug(s) that this PR fixes_

- Template should be strictly **<172>**
- Example: Closes #172

## Prerequisites

- [ yes ] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
